### PR TITLE
modify expect pattern

### DIFF
--- a/tomahawk/expect.py
+++ b/tomahawk/expect.py
@@ -32,7 +32,7 @@ class CommandWithExpect(object):
         self.log = create_logger(None, debug_enabled)
         self.expect_patterns = [
             b('^Enter passphrase.+'),
-            b('[Pp]assword.*:'),
+            b('[Pp]assword[^\n]*:'),
             u('パスワード').encode('utf-8'), # TODO: japanese character expected as utf-8
         ]
         if expect_out is None:


### PR DESCRIPTION
because expect_patterns mached when chef-client stdout "cookbook_file[/tmp/ldap_setup/etc_pam.d_common-password]" and line breaks and ":"

for example...
```
* cookbook_file[/tmp/ldap_setup/etc_pam.d_common-password] action create[0m (up to date)[0m
* cookbook_file[/tmp/ldap_setup/etc_pam.d_common-auth] action create[0m (up to date)[0m
* cookbook_file[/tmp/ldap_setup/etc_pam.d_common-account] action create[0m (up to date)[0m
* cookbook_file[/tmp/ldap_setup/etc_openldap_ldap.conf] action create[0m (up to date)[0m
* cookbook_file[/tmp/ldap_setup/etc_openldap_cacerts_ldaps.crt] action create[0m (up to date)[0m
* cookbook_file[/tmp/ldap_setup/etc_nsswitch.conf] action create[0m (up to date)[0m
* cookbook_file[/tmp/ldap_setup/etc_ldap_ldap.conf] action create[0m (up to date)[0m
* cookbook_file[/tmp/ldap_setup/README_CHEF.txt] action create[0m (up to date)[0m
(up to date) [0m
Recipe: dummy::_ldap_setup[0m
```